### PR TITLE
Fix c++ linker errors for arm64-v8a

### DIFF
--- a/ncnn-android-yolov8/app/build.gradle
+++ b/ncnn-android-yolov8/app/build.gradle
@@ -10,12 +10,25 @@ android {
 
         minSdkVersion 24
         targetSdkVersion 34
+
+        // Enable shared libc++ runtime in native build
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_STL=c++_shared"
+            }
+        }
     }
 
+    // Path to CMakeLists
     externalNativeBuild {
         cmake {
             path file('src/main/jni/CMakeLists.txt')
         }
+    }
+
+    // 有些第三方库也带自己的 libc++_shared.so，防止重复文件冲突
+    packagingOptions {
+        pickFirst "**/libc++_shared.so"
     }
 }
 

--- a/ncnn-android-yolov8/app/build.gradle
+++ b/ncnn-android-yolov8/app/build.gradle
@@ -11,6 +11,11 @@ android {
         minSdkVersion 24
         targetSdkVersion 34
 
+        // 限制仅构建 arm64-v8a，避免缺失 x86/OpenCV 预编译包导致的配置错误
+        ndk {
+            abiFilters "arm64-v8a"
+        }
+
         // Enable shared libc++ runtime in native build
         externalNativeBuild {
             cmake {

--- a/ncnn-android-yolov8/app/src/main/jni/CMakeLists.txt
+++ b/ncnn-android-yolov8/app/src/main/jni/CMakeLists.txt
@@ -15,6 +15,17 @@ if(NOT ncnn_DIR)
 endif()
 find_package(ncnn REQUIRED)
 
+# 目标
 add_library(yolov8ncnn SHARED yolov8ncnn.cpp yolo.cpp ndkcamera.cpp)
 
-target_link_libraries(yolov8ncnn ncnn ${OpenCV_LIBS} camera2ndk mediandk)
+# 明确链接共享 libc++ 避免缺失符号
+find_library(cpp_shared NAMES c++_shared REQUIRED)
+
+# 链接库
+target_link_libraries(yolov8ncnn
+        PRIVATE
+        ncnn
+        ${OpenCV_LIBS}
+        camera2ndk
+        mediandk
+        ${cpp_shared})


### PR DESCRIPTION
Configure Gradle to include `libc++_shared.so` in the APK and adjust `packagingOptions`.

This fixes a `java.lang.UnsatisfiedLinkError: libc++_shared.so not found` at runtime by ensuring the shared C++ runtime library is packaged with the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-d92fd8ff-11bd-4f83-8a7e-39b346f4a0f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d92fd8ff-11bd-4f83-8a7e-39b346f4a0f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

